### PR TITLE
Fixed typo "stip()" >> "strip()"

### DIFF
--- a/vt/vt.py
+++ b/vt/vt.py
@@ -3339,7 +3339,7 @@ daily_limit=100
                     apikey.strip(),
                     type_key.strip(),
                     intelligence.strip(),
-                    user.stip(),
+                    user.strip(),
                     password.strip(),
                     notify.strip(),
                     share_user.strip(),


### PR DESCRIPTION
Just a little fix of a typo.
Thanks for all the good work! :)